### PR TITLE
Compact works fine with GHC-8.4. Update base dependency accordingly.

### DIFF
--- a/compact.cabal
+++ b/compact.cabal
@@ -28,7 +28,7 @@ extra-source-files:  README.md tests/sample1.hs tests/sample2.hs
 library
   exposed-modules:     Data.Compact
                        Data.Compact.Serialize
-  build-depends:       base       >= 4.10 && < 4.11,
+  build-depends:       base       >= 4.10 && < 4.12,
                        ghc-compact,
                        -- TODO: SomeTypeRep instance is in unreleased version
                        -- of binary that is bundled with GHC dev branch


### PR DESCRIPTION
This fixes issue #5 